### PR TITLE
update Go to 1.25.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sil-org/config-shim
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.36.1


### PR DESCRIPTION
### Security
- Update Go to 1.25.12 for [GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856).